### PR TITLE
Comprovar credencials i aturar si no són bones

### DIFF
--- a/src/ListenerEngine.Mastonet/MastonetListener.cs
+++ b/src/ListenerEngine.Mastonet/MastonetListener.cs
@@ -33,12 +33,20 @@ public class MastonetListener : ListenerEngine.IListener
 
 	public void Start()
 	{
+		CheckCredentials();
+
 		streaming = client.GetPublicLocalStreaming();
 		streaming.OnUpdate += OnUpdate;
 		streaming.Start();
 	}
 
-	private void OnUpdate(object? sender, StreamUpdateEventArgs e)
+    private void CheckCredentials()
+    {
+		var usr = client.GetCurrentUser().GetAwaiter().GetResult();			
+		logger.LogDebug("Connectat com {}", usr.AccountName);
+    }
+
+    private void OnUpdate(object? sender, StreamUpdateEventArgs e)
 	{
 		var tootId = e.Status.Id;
 		var accountId = e.Status.Account.Id;

--- a/src/ListenerEngine.Mastonet/MastonetListener.cs
+++ b/src/ListenerEngine.Mastonet/MastonetListener.cs
@@ -31,18 +31,24 @@ public class MastonetListener : ListenerEngine.IListener
 		}
 	}
 
-	public void Start()
-	{
-		CheckCredentials();
-
-		streaming = client.GetPublicLocalStreaming();
-		streaming.OnUpdate += OnUpdate;
-		streaming.Start();
-	}
-
-    private void CheckCredentials()
+	public async Task Start()
     {
-		var usr = client.GetCurrentUser().GetAwaiter().GetResult();			
+        await CheckCredentials();
+
+        streaming = client.GetPublicLocalStreaming();
+        streaming.OnUpdate += OnUpdate;
+
+        StartTask();
+    }
+
+    private void StartTask()
+    {
+        streaming!.Start();
+    }
+
+    private async Task CheckCredentials()
+    {
+		var usr = await client.GetCurrentUser();			
 		logger.LogDebug("Connectat com {}", usr.AccountName);
     }
 

--- a/src/ListenerEngine/IListener.cs
+++ b/src/ListenerEngine/IListener.cs
@@ -2,5 +2,5 @@
 public interface IListener : IDisposable
 {   
     event EventHandler<ListenerEventArgs>? NewMediaToot; 
-    void Start();
+    Task Start();
 }

--- a/src/MastoAltText/Program.cs
+++ b/src/MastoAltText/Program.cs
@@ -15,9 +15,9 @@ IHost host =
 			// json, env vars or command line arguments.
 			hostConfig.SetBasePath(Directory.GetCurrentDirectory());
 			hostConfig.AddJsonFile("mastodoncredentials.json", optional: true);
-			hostConfig.AddEnvironmentVariables(prefix: "MASTOALTTEXT_");
-			hostConfig.AddCommandLine(args);
+			hostConfig.AddEnvironmentVariables(prefix: "MASTOALTTEXT_");			
 			hostConfig.AddUserSecrets(Assembly.GetExecutingAssembly(), true);
+			hostConfig.AddCommandLine(args);
 		}
 	)
 	.ConfigureServices((hostBuilderContext, services) =>

--- a/src/MastoAltText/Worker.cs
+++ b/src/MastoAltText/Worker.cs
@@ -27,7 +27,7 @@ public class Worker : IHostedService
 		this.sender = sender;
 	}
 
-	public Task StartAsync(CancellationToken cancellationToken)
+	public async Task StartAsync(CancellationToken cancellationToken)
 	{
 		logger.LogInformation("Worker running");
 		listener.NewMediaToot += async (s, e) =>
@@ -46,8 +46,7 @@ public class Worker : IHostedService
 			}
 		};
 
-		listener.Start();
-		return Task.CompletedTask;
+		await listener.Start();
 	}
 
 	public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivació

* Closes #3 

### En aquesta PR

* Abans de fer streaming de local es prova de llegir les dades del propi compte, si les credencials no són bones l'aplicació fa excepció i s'atura.

>Unhandled exception. Mastonet.ServerErrorException: L'identificador d'accés és invàlid
